### PR TITLE
 Allow ArrayVec to be generic with efficent default LenT 

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -11,8 +11,8 @@ use std::str;
 use std::str::FromStr;
 use std::str::Utf8Error;
 
-use crate::{CapacityError, DefaultLenUint};
-use crate::LenUint;
+use crate::len_type::{LenUint, DefaultLenType, assert_capacity_limit, assert_capacity_limit_const};
+use crate::CapacityError;
 use crate::char::encode_utf8;
 use crate::utils::MakeMaybeUninit;
 
@@ -32,7 +32,7 @@ use serde::{Serialize, Deserialize, Serializer, Deserializer};
 /// if needed.
 #[derive(Copy)]
 #[repr(C)]
-pub struct ArrayString<const CAP: usize, LenType: LenUint = DefaultLenUint> {
+pub struct ArrayString<const CAP: usize, LenType: LenUint = DefaultLenType<CAP>> {
     // the `len` first elements of the array are initialized
     len: LenType,
     xs: [MaybeUninit<u8>; CAP],
@@ -114,7 +114,7 @@ impl<const CAP: usize, LenType: LenUint> ArrayString<CAP, LenType>
     /// ```
     /// use arrayvec::ArrayString;
     ///
-    /// let string = ArrayString::from_byte_string(b"hello world").unwrap();
+    /// let string = ArrayString::<11>::from_byte_string(b"hello world").unwrap();
     /// ```
     pub fn from_byte_string(b: &[u8; CAP]) -> Result<Self, Utf8Error> {
         let len = str::from_utf8(b)?.len();

--- a/src/len_type.rs
+++ b/src/len_type.rs
@@ -1,0 +1,72 @@
+use core::ops::{Add, Sub};
+
+macro_rules! impl_lenuint {
+    ($Sealed:ty, $LenUint:ty, $ty: path) => {
+        impl $Sealed for $ty {}
+        impl $LenUint for $ty {
+            const MAX: usize = <$ty>::MAX as usize;
+            const ZERO: Self = 0;
+            fn from_usize(n: usize) -> Self { n as $ty }
+            fn to_usize(self) -> usize { self as usize }
+        }
+    };
+}
+
+macro_rules! impl_default_lentype_from_cap {
+    ($LenT:ty => $($CAP:literal),*) => {
+        $(
+            impl CapToDefaultLenType for CapToLenType<$CAP> {
+                type T = $LenT;
+            }
+        )*
+    };
+}
+
+macro_rules! assert_capacity_limit {
+    ($ty: path, $cap:expr) => {
+        if $cap > <$ty as LenUint>::MAX {
+            panic!("ArrayVec: capacity {} is too large for {}::MAX={}", CAP, std::any::type_name::<$ty>(), <$ty as LenUint>::MAX)
+        }
+    }
+}
+
+macro_rules! assert_capacity_limit_const {
+    ($ty: path, $cap:expr) => {
+        if $cap > <$ty as LenUint>::MAX {
+            panic!("ArrayVec: capacity is too large for LenUint::MAX")
+        }
+    }
+}
+
+pub trait LenUint: Add + Sub + Copy + PartialOrd + PartialEq + private::Sealed  {
+    const MAX: usize;
+    const ZERO: Self;
+    fn from_usize(n: usize) -> Self;
+    fn to_usize(self) -> usize;
+}
+
+mod private {
+    pub trait Sealed {}
+
+    impl_lenuint!(Sealed, super::LenUint, u8);
+    impl_lenuint!(Sealed, super::LenUint, u16);
+    impl_lenuint!(Sealed, super::LenUint, u32);
+    #[cfg(target_pointer_width = "64")]
+    impl_lenuint!(Sealed, super::LenUint, u64);
+    impl_lenuint!(Sealed, super::LenUint, usize);
+}
+
+pub struct CapToLenType<const CONST: usize> {}
+
+pub trait CapToDefaultLenType {
+    type T: LenUint;
+}
+
+impl_default_lentype_from_cap!(u8 => 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 32, 64, 100, 128, 200, 255);
+impl_default_lentype_from_cap!(u16 => 256, 500, 512, 1000, 1024, 2048, 4096, 8192, 16384, 32768, 65535);
+impl_default_lentype_from_cap!(u32 => 65536, 1000000, 4294967295);
+impl_default_lentype_from_cap!(u64 => 18446744073709551615);
+
+pub(crate) type DefaultLenType<const CAP: usize> = <CapToLenType<CAP> as CapToDefaultLenType>::T;
+
+pub(crate) use {assert_capacity_limit, assert_capacity_limit_const};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,48 +28,7 @@ extern crate serde;
 #[cfg(not(feature="std"))]
 extern crate core as std;
 
-pub trait LenUint: Add + Sub + Copy + PartialOrd + PartialEq + private::Sealed  {
-    const MAX: usize;
-    const ZERO: Self;
-    fn from_usize(n: usize) -> Self;
-    fn to_usize(self) -> usize;
-}
-macro_rules! impl_lenuint {
-    ($ty: path) => {
-        impl $crate::private::Sealed for $ty {}
-        impl $crate::LenUint for $ty {
-            const MAX: usize = <$ty>::MAX as usize;
-            const ZERO: Self = 0;
-            fn from_usize(n: usize) -> Self { n as $ty }
-            fn to_usize(self) -> usize { self as usize }
-        }
-    };
-}
-mod private {
-    pub trait Sealed {}
-    impl_lenuint!(u8);
-    impl_lenuint!(u16);
-    impl_lenuint!(u32);
-    #[cfg(target_pointer_width = "64")]
-    impl_lenuint!(u64);
-    impl_lenuint!(usize);
-}
-macro_rules! assert_capacity_limit {
-    ($ty: path, $cap:expr) => {
-        if $cap > <$ty as LenUint>::MAX {
-            panic!("ArrayVec: capacity {} is too large for {}::MAX={}", CAP, std::any::type_name::<$ty>(), <$ty as LenUint>::MAX)
-        }
-    }
-}
-
-macro_rules! assert_capacity_limit_const {
-    ($ty: path, $cap:expr) => {
-        if $cap > <$ty as LenUint>::MAX {
-            panic!("ArrayVec: capacity is too large for LenUint::MAX")
-        }
-    }
-}
-pub type DefaultLenUint = u32;
+mod len_type;
 mod arrayvec_impl;
 mod arrayvec;
 mod array_string;
@@ -77,9 +36,8 @@ mod char;
 mod errors;
 mod utils;
 
-use core::ops::Sub;
-use std::ops::Add;
 pub use crate::array_string::ArrayString;
 pub use crate::errors::CapacityError;
+pub use len_type::LenUint;
 
 pub use crate::arrayvec::{ArrayVec, IntoIter, Drain};

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -737,32 +737,6 @@ fn test_try_from_argument() {
 }
 
 #[test]
-fn allow_max_capacity_arrayvec_type() {
-    // this type is allowed to be used (but can't be constructed)
-    let _v: ArrayVec<(), { usize::MAX }>;
-}
-
-#[should_panic(expected = "largest supported capacity")]
-#[test]
-fn deny_max_capacity_arrayvec_value() {
-    if mem::size_of::<usize>() <= mem::size_of::<u32>() {
-        panic!("This test does not work on this platform. 'largest supported capacity'");
-    }
-    // this type is allowed to be used (but can't be constructed)
-    let _v: ArrayVec<(), { usize::MAX }> = ArrayVec::new();
-}
-
-#[should_panic(expected = "index out of bounds")]
-#[test]
-fn deny_max_capacity_arrayvec_value_const() {
-    if mem::size_of::<usize>() <= mem::size_of::<u32>() {
-        panic!("This test does not work on this platform. 'index out of bounds'");
-    }
-    // this type is allowed to be used (but can't be constructed)
-    let _v: ArrayVec<(), { usize::MAX }> = ArrayVec::new_const();
-}
-
-#[test]
 fn test_arrayvec_const_constructible() {
     const OF_U8: ArrayVec<Vec<u8>, 10> = ArrayVec::new_const();
 


### PR DESCRIPTION
I fixed the `From<[T, CAP]>` inference! and made the default length default to more efficient types than u32 more often then not!

I also organized the LenT specific code into it's own file, to prevent it bloating the lib.rs.