### PR TITLE
make automatic length detection feature-gated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ harness = false
 [features]
 default = ["std"]
 std = []
+nightly = []
 
 [profile.bench]
 debug = true

--- a/src/len_type.rs
+++ b/src/len_type.rs
@@ -6,8 +6,12 @@ macro_rules! impl_lenuint {
         impl $LenUint for $ty {
             const MAX: usize = <$ty>::MAX as usize;
             const ZERO: Self = 0;
-            fn from_usize(n: usize) -> Self { n as $ty }
-            fn to_usize(self) -> usize { self as usize }
+            fn from_usize(n: usize) -> Self {
+                n as $ty
+            }
+            fn to_usize(self) -> usize {
+                self as usize
+            }
         }
     };
 }
@@ -15,6 +19,7 @@ macro_rules! impl_lenuint {
 macro_rules! impl_default_lentype_from_cap {
     ($LenT:ty => $($CAP:literal),*) => {
         $(
+            #[cfg(feature = "nightly")]
             impl CapToDefaultLenType for ConstGenericSmuggler<$CAP> {
                 type T = $LenT;
             }
@@ -22,7 +27,7 @@ macro_rules! impl_default_lentype_from_cap {
     };
 }
 
-pub trait LenUint: Add + Sub + Copy + PartialOrd + PartialEq + private::Sealed  {
+pub trait LenUint: Add + Sub + Copy + PartialOrd + PartialEq + private::Sealed {
     const MAX: usize;
     const ZERO: Self;
     fn from_usize(n: usize) -> Self;
@@ -46,9 +51,16 @@ pub trait CapToDefaultLenType {
     type T: LenUint;
 }
 
+impl<const CAP: usize> CapToDefaultLenType for ConstGenericSmuggler<CAP> {
+    #[cfg(not(feature = "nightly"))]
+    type T = u32;
+    #[cfg(feature = "nightly")]
+    default type T = u32;
+}
+
 impl_default_lentype_from_cap!(u8 => 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 32, 64, 100, 128, 200, 255);
 impl_default_lentype_from_cap!(u16 => 256, 500, 512, 1000, 1024, 2048, 4096, 8192, 16384, 32768, 65535);
-impl_default_lentype_from_cap!(u32 => 65536, 1000000, 4294967295);
+// impl_default_lentype_from_cap!(u32 => 65536, 1000000, 4294967295);
 impl_default_lentype_from_cap!(u64 => 18446744073709551615);
 
 pub trait CapFitsInLenType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! **arrayvec** provides the types [`ArrayVec`] and [`ArrayString`]: 
+//! **arrayvec** provides the types [`ArrayVec`] and [`ArrayString`]:
 //! array-backed vector and string types, which store their contents inline.
 //!
 //! The arrayvec package has the following cargo features:
@@ -19,25 +19,26 @@
 //!
 //! This version of arrayvec requires Rust 1.51 or later.
 //!
-#![doc(html_root_url="https://docs.rs/arrayvec/0.7/")]
-#![cfg_attr(not(feature="std"), no_std)]
+#![doc(html_root_url = "https://docs.rs/arrayvec/0.7/")]
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "nightly", feature(specialization))]
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 extern crate serde;
 
-#[cfg(not(feature="std"))]
+#[cfg(not(feature = "std"))]
 extern crate core as std;
 
-mod len_type;
-mod arrayvec_impl;
-mod arrayvec;
 mod array_string;
+mod arrayvec;
+mod arrayvec_impl;
 mod char;
 mod errors;
+mod len_type;
 mod utils;
 
 pub use crate::array_string::ArrayString;
 pub use crate::errors::CapacityError;
 pub use len_type::LenUint;
 
-pub use crate::arrayvec::{ArrayVec, IntoIter, Drain};
+pub use crate::arrayvec::{ArrayVec, Drain, IntoIter};


### PR DESCRIPTION
I think that the automatic length detection is cool, but I'm not sure how actually useful it is. As it is, the following code doesn't compile:
```rust
let a: ArrayVec<u8, 17> = ArrayVec::new();
```
Worse, the error message is confusing:
```
   Compiling t v0.1.0 (/home/wschroeder/Projects/t)
error[E0277]: the trait bound `arrayvec::len_type::ConstGenericSmuggler<17>: arrayvec::len_type::CapToDefaultLenType` is not satisfied
 --> src/main.rs:4:12
  |
4 |     let a: ArrayVec<u8, 17> = ArrayVec::new();
  |            ^^^^^^^^^^^^^^^^ the trait `arrayvec::len_type::CapToDefaultLenType` is not implemented for `arrayvec::len_type::ConstGenericSmuggler<17>`
  |
  = help: the following other types implement trait `arrayvec::len_type::CapToDefaultLenType`:
            arrayvec::len_type::ConstGenericSmuggler<0>
            arrayvec::len_type::ConstGenericSmuggler<1000000>
            arrayvec::len_type::ConstGenericSmuggler<1000>
            arrayvec::len_type::ConstGenericSmuggler<100>
            arrayvec::len_type::ConstGenericSmuggler<1024>
            arrayvec::len_type::ConstGenericSmuggler<10>
            arrayvec::len_type::ConstGenericSmuggler<11>
            arrayvec::len_type::ConstGenericSmuggler<128>
          and 30 others

For more information about this error, try `rustc --explain E0277`.
error: could not compile `t` (bin "t") due to 1 previous error
```
I just feel like the automatic length detection is reinventing the wheel whilst making code which used to compile break. Personally, I'd rather it just default to a u32, and you can specify a smaller type if your space requirements are particularly confining (or if u32::MAX is too small), rather than having code that used to compile not compile in a vast majority of circumstances.
There are defaults for 23/256 possible u8 lengths. The whole point of the automatic length detection is to save the user having to write
```rust
let a: ArrayVec<u8, 17, u8> = ArrayVec::new();
//                    ^^^^ this
```
when in a vast majority of circumstances (assuming even distribution of lengths, thats ~91% of u8s, ~99.98% of u16s, ~99.999999993% of u32s, and some ridiculous number for u64 that my calculator won't display) the user will have to write it anyway. It just seems like there's not much point, and we are better off leaving performance to be opt-in.

In nightly, we can use #![feature(specialization)] to allow a default implementation with u32, solving the problem and giving us the best of both worlds - but it should be gated behind a nightly feature, which is what I've done here.